### PR TITLE
Add per-process resource requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,23 @@
-FROM ubuntu LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" \
-	description="Docker image containing all requirements for LncPipe"
-# Update OS # DEBIAN_FRONTEND=noninteractive is for relieving the dependence of readline perl library by prohibiting interactive frontend # default-jre is for NextFlow (run groovy) # gcc and g++ is for compiling CPAT, PLEK as well as some R packages # gfortran is for compiling R package hexbin (required by plotly) # make is for executing makefiles for several tools # Cython provides C header files like Python.h for CPAT compiling # DO NOT use pip for installing Cython, which will cause missing .h files # zlib1g-dev is for CPAT compiling dependency # libncurses5-dev for samtools (may be used later) # libssl-dev is for R package openssl # libcurl4-openssl-dev is for R package curl # perl brings us FindBin module, which is required by FastQC # ca-certificates is required by aria2 RUN export DEBIAN_FRONTEND=noninteractive && \
+FROM ubuntu
+
+LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" description="Docker image containing all requirements for LncPipe"
+
+# Update OS
+# DEBIAN_FRONTEND=noninteractive is for relieving the dependence of readline perl library by prohibiting interactive frontend
+# default-jre is for NextFlow (run groovy)
+# gcc and g++ is for compiling CPAT, PLEK as well as some R packages
+# gfortran is for compiling R package hexbin (required by plotly)
+# make is for executing makefiles for several tools
+# Cython provides C header files like Python.h for CPAT compiling
+# DO NOT use pip for installing Cython, which will cause missing .h files
+# zlib1g-dev is for CPAT compiling dependency
+# libncurses5-dev for samtools (may be used later)
+# libssl-dev is for R package openssl
+# libcurl4-openssl-dev is for R package curl
+# perl brings us FindBin module, which is required by FastQC
+# ca-certificates is required by aria2
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
 	apt-get -qq update && \
 	apt-get -qq install -y --no-install-recommends \
 	default-jre \
@@ -17,34 +34,57 @@ FROM ubuntu LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" \
 	zlib1g-dev \
 	libssl-dev \
 	libcurl4-openssl-dev \
+	libpng16-16 \
 	perl \
-	ca-certificates
-# Install latest pip WITHOUT wheel and setuptools # DO NOT use apt-get python-pip in ubuntu for preventing from complicated related tools and libraries # Setuptools is required by CPAT during its installation RUN aria2c https://bootstrap.pypa.io/get-pip.py -q -o /opt/get-pip.py && \
+	ca-certificates && \
+	cd /usr/lib/x86_64-linux-gnu && ln -s libpng16.so.16.28.0 libpng12.so.0
+
+# Install latest pip WITHOUT wheel and setuptools
+# DO NOT use apt-get python-pip in ubuntu for preventing from complicated related tools and libraries
+# Setuptools is required by CPAT during its installation
+RUN aria2c https://bootstrap.pypa.io/get-pip.py -q -o /opt/get-pip.py && \
 	python /opt/get-pip.py --no-wheel && \
 	rm /opt/get-pip.py
-# Install required python packages	RUN pip -qqq install numpy
-# Install nextflow RUN aria2c https://github.com/nextflow-io/nextflow/releases/download/v0.25.6/nextflow -q -o /opt/nextflow && \
+# Install required python packages
+RUN pip -qqq install numpy
+# Install nextflow
+RUN aria2c https://github.com/nextflow-io/nextflow/releases/download/v0.25.6/nextflow -q -o /opt/nextflow && \
 	chmod 777 /opt/nextflow && \
 	ln -s /opt/nextflow /usr/local/bin
-# Install STAR RUN aria2c https://raw.githubusercontent.com/alexdobin/STAR/master/bin/Linux_x86_64/STAR -q -o /opt/STAR && \
+# Install STAR
+RUN aria2c https://raw.githubusercontent.com/alexdobin/STAR/master/bin/Linux_x86_64/STAR -q -o /opt/STAR && \
 	chmod 777 /opt/STAR && \
 	ln -s /opt/STAR /usr/local/bin
-# Install cufflinks	RUN aria2c https://github.com/bioinformatist/cufflinks/releases/download/v2.2.1/cufflinks-2.2.1.Linux_x86_64.tar.gz -q -o /opt/cufflinks-2.2.1.Linux_x86_64.tar.gz && \
+# Install cufflinks
+RUN aria2c https://github.com/bioinformatist/cufflinks/releases/download/v2.2.1/cufflinks-2.2.1.Linux_x86_64.tar.gz -q -o /opt/cufflinks-2.2.1.Linux_x86_64.tar.gz && \
 	tar xf /opt/cufflinks-2.2.1.Linux_x86_64.tar.gz --use-compress-prog=pigz -C /opt/ && \
 	rm /opt/cufflinks-2.2.1.Linux_x86_64/README && \
 	ln -s /opt/cufflinks-2.2.1.Linux_x86_64/* /usr/local/bin/ && \
 	rm /opt/cufflinks-2.2.1.Linux_x86_64.tar.gz
-# Install PLEK # Remove documents, demo files, source files, object files and R scripts # dos2unix in perl one-liner: remove BOM head and deal with \r problem RUN aria2c https://ncu.dl.sourceforge.net/project/plek/PLEK.1.2.tar.gz -q -o /opt/PLEK.1.2.tar.gz && \
-	tar xf /opt/PLEK.1.2.tar.gz --use-compress-prog=pigz -C /opt/ && \
-	cd /opt/PLEK.1.2/ && \
-	python PLEK_setup.py || : && \
-	rm *.pdf *.txt *.h *.c *.fa *.cpp *.o *.R *.doc PLEK_setup.py && \
-	chmod 777 * && \
-	perl -CD -pi -e'tr/\x{feff}//d && s/[\r\n]+/\n/' *.py && \
-	ln -s /opt/PLEK.1.2/PLEK* /usr/local/bin/ && \
-	ln -s /opt/PLEK.1.2/svm* /usr/local/bin/ && \
-	rm /opt/PLEK.1.2.tar.gz
-# Use bash instead for shopt only works with bash SHELL ["/bin/bash", "-c"] # Install CNCI # Enable the extglob shell option # Parentheses and the pipe symbol should be escaped RUN aria2c https://codeload.github.com/www-bioinfo-org/CNCI/zip/master -q -o /opt/CNCI-master.zip && \
+
+# Install PLEK
+# Remove documents, demo files, source files, object files and R scripts
+# dos2unix in perl one-liner: remove BOM head and deal with \r problem
+RUN aria2c https://excellmedia.dl.sourceforge.net/project/plek/PLEK.1.2.tar.gz -q -o /opt/PLEK.1.2.tar.gz && \
+		tar xf /opt/PLEK.1.2.tar.gz --use-compress-prog=pigz -C /opt/ && \
+		cd /opt/PLEK.1.2/ && \
+		python PLEK_setup.py || : && \
+		rm *.pdf *.txt *.h *.c *.fa *.cpp *.o *.R *.doc PLEK_setup.py && \
+		chmod 777 * && \
+		perl -CD -pi -e'tr/\x{feff}//d && s/[\r\n]+/\n/' *.py && \
+		ln -s /opt/PLEK.1.2/PLEK* /usr/local/bin/ && \
+		ln -s /opt/PLEK.1.2/svm* /usr/local/bin/ && \
+		rm /opt/PLEK.1.2.tar.gz
+
+# Use bash instead for shopt only works with bash
+
+SHELL ["/bin/bash", "-c"]
+
+
+# Install CNCI
+# Enable the extglob shell option
+# Parentheses and the pipe symbol should be escaped
+RUN aria2c https://codeload.github.com/www-bioinfo-org/CNCI/zip/master -q -o /opt/CNCI-master.zip && \
 	unzip -qq /opt/CNCI-master.zip -d /opt/ && \
 	rm /opt/CNCI-master.zip && \
 	unzip -qq /opt/CNCI-master/libsvm-3.0.zip -d /opt/CNCI-master/ && \
@@ -57,39 +97,58 @@ FROM ubuntu LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" \
 	rm draw_class_pie.R LICENSE README.md && \
 	chmod -R 777 * && \
 	ln -s /opt/CNCI-master/*.py /usr/local/bin/
-# Install CPAT # DO NOT use absolute path when setup, and changing directory is necessary. Python interpreter will check current directory for dependencies # Remove line 21 from setup.py: distribute_setup::use_setuptools() for: https://stackoverflow.com/questions/46967488/getting-error-403-while-installing-package-with-pip/46979531#46979531 RUN aria2c https://nchc.dl.sourceforge.net/project/rna-cpat/v1.2.3/CPAT-1.2.3.tar.gz -q -o /opt/CPAT-1.2.3.tar.gz && \
-	tar xf /opt/CPAT-1.2.3.tar.gz --use-compress-prog=pigz -C /opt/ && \
-	cd /opt/CPAT-1.2.3/ && \
-	perl -i -lanE'say unless $. == 21' setup.py && \
-	python setup.py install && \
-	rm -rfv !"dat" && \
-	chmod -R 777 *
-# Set back to default shell SHELL ["/bin/sh", "-c"] # Install StringTie RUN aria2c http://ccb.jhu.edu/software/stringtie/dl/stringtie-1.3.3b.Linux_x86_64.tar.gz -q -o /opt/stringtie-1.3.3b.Linux_x86_64.tar.gz && \
+
+# Install CPAT
+# DO NOT use absolute path when setup, and changing directory is necessary. Python interpreter will check current directory for dependencies
+# Remove line 21 from setup.py: distribute_setup::use_setuptools() for: https://stackoverflow.com/questions/46967488/getting-error-403-while-installing-package-with-pip/46979531#46979531
+RUN aria2c https://excellmedia.dl.sourceforge.net/project/rna-cpat/v1.2.3/CPAT-1.2.3.tar.gz -q -o /opt/CPAT-1.2.3.tar.gz && \
+		tar xf /opt/CPAT-1.2.3.tar.gz --use-compress-prog=pigz -C /opt/ && \
+		cd /opt/CPAT-1.2.3/ && \
+		perl -i -lanE'say unless $. == 21' setup.py && \
+		python setup.py install && \
+		rm -rfv !"dat" && \
+		chmod -R 777 *
+
+# Set back to default shell
+SHELL ["/bin/sh", "-c"]
+
+# Install StringTie
+RUN aria2c http://ccb.jhu.edu/software/stringtie/dl/stringtie-1.3.3b.Linux_x86_64.tar.gz -q -o /opt/stringtie-1.3.3b.Linux_x86_64.tar.gz && \
 	tar xf /opt/stringtie-1.3.3b.Linux_x86_64.tar.gz --use-compress-prog=pigz -C /opt/ && \
 	rm /opt/stringtie-1.3.3b.Linux_x86_64/README && \
 	ln -s /opt/stringtie-1.3.3b.Linux_x86_64/stringtie /usr/local/bin/stringtie && \
 	rm /opt/stringtie-1.3.3b.Linux_x86_64.tar.gz
-# Install Hisat2	RUN aria2c ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.1.0-Linux_x86_64.zip -q -o /opt/hisat2-2.1.0-Linux_x86_64.zip && \
+# Install Hisat2
+RUN aria2c ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.1.0-Linux_x86_64.zip -q -o /opt/hisat2-2.1.0-Linux_x86_64.zip && \
 	unzip -qq /opt/hisat2-2.1.0-Linux_x86_64.zip -d /opt/ && \
 	rm /opt/hisat2-2.1.0-Linux_x86_64.zip && \
 	cd /opt/hisat2-2.1.0 && \
 	rm -rf doc example *debug MANUAL* NEWS TUTORIAL && \
 	ln -s /opt/hisat2-2.1.0/hisat2* /usr/local/bin/ && \
 	ln -sf /opt/hisat2-2.1.0/*.py /usr/local/bin/
-# Install Kallisto # There's some trashy pointers in Kallisto tarball archieve RUN aria2c https://github.com/pachterlab/kallisto/releases/download/v0.43.1/kallisto_linux-v0.43.1.tar.gz -q -o  /opt/kallisto_linux-v0.43.1.tar.gz && \
+# Install Kallisto
+# There's some trashy pointers in Kallisto tarball archieve
+RUN aria2c https://github.com/pachterlab/kallisto/releases/download/v0.43.1/kallisto_linux-v0.43.1.tar.gz -q -o  /opt/kallisto_linux-v0.43.1.tar.gz && \
 	tar xf /opt/kallisto_linux-v0.43.1.tar.gz --use-compress-prog=pigz -C /opt/ && \
 	cd /opt && \
 	rm ._* kallisto_linux-v0.43.1.tar.gz && \
 	cd kallisto_linux-v0.43.1 && \
 	rm -rf ._* 	README.md test && \
 	ln -s /opt/kallisto_linux-v0.43.1/kallisto /usr/local/bin/
-# Install Microsoft-R-Open with MKL, you must use MRO v3.4.2 or later # For more, see this GitHub issue comment: https://github.com/Microsoft/microsoft-r-open/issues/26#issuecomment-340276347 RUN aria2c https://mran.blob.core.windows.net/install/mro/3.4.2/microsoft-r-open-3.4.2.tar.gz -q -o /opt/microsoft-r-open-3.4.2.tar.gz && \
+# Install Microsoft-R-Open with MKL, you must use MRO v3.4.2 or later
+# For more, see this GitHub issue comment: https://github.com/Microsoft/microsoft-r-open/issues/26#issuecomment-340276347
+RUN aria2c https://mran.blob.core.windows.net/install/mro/3.4.2/microsoft-r-open-3.4.2.tar.gz -q -o /opt/microsoft-r-open-3.4.2.tar.gz && \
 	tar xf /opt/microsoft-r-open-3.4.2.tar.gz --use-compress-prog=pigz -C /opt/ && \
 	cd /opt/microsoft-r-open && \
 	./install.sh -as && \
 	rm -rf /opt/microsoft-r*
-# Cleaning up the apt cache helps keep the image size down (must be placed here, since MRO installation need the cache) RUN rm -rf /var/lib/apt/lists/*
-# Install cpanminus # RUN aria2c https://cpanmin.us/ -q -o /opt/cpanm && \ #	chmod +x /opt/cpanm && \ #	ln -s /opt/cpanm /usr/local/bin/ # Install Perl module FindBin, which is required by FastQC # RUN cpanm FindBin # Install FastQC RUN aria2c https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip -q -o /opt/fastqc_v0.11.5.zip && \
+# Cleaning up the apt cache helps keep the image size down (must be placed here, since MRO installation need the cache)
+RUN rm -rf /var/lib/apt/lists/*
+
+# Install cpanminus #RUN aria2c https://cpanmin.us/ -q -o /opt/cpanm && \ #chmod +x /opt/cpanm && \ #	ln -s /opt/cpanm /usr/local/bin/ # Install Perl module FindBin, which is required by FastQC # RUN cpanm FindBin
+
+# Install FastQC
+RUN aria2c https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip -q -o /opt/fastqc_v0.11.5.zip && \
 	unzip -qq /opt/fastqc_v0.11.5.zip -d /opt/ && \
 	rm /opt/fastqc_v0.11.5.zip && \
 	cd /opt/FastQC && \
@@ -97,18 +156,23 @@ FROM ubuntu LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" \
 	rm -rfv !\("fastqc"\|*.jar\) && \
 	chmod 777 * && \
 	ln -s /opt/FastQC/fastqc /usr/local/bin/
-# Install Pandoc (required by reporter) RUN aria2c https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb -q -o /opt/pandoc-1.19.2.1-1-amd64.deb && \
+# Install Pandoc (required by reporter)
+RUN aria2c https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb -q -o /opt/pandoc-1.19.2.1-1-amd64.deb && \
 	dpkg -i /opt/pandoc-1.19.2.1-1-amd64.deb && \
 	rm /opt/pandoc-1.19.2.1-1-amd64.deb
-# Install PyPy RUN aria2c https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.9-linux_x86_64-portable.tar.bz2 -q -o /opt/pypy-5.9-linux_x86_64-portable.tar.bz2 && \
+# Install PyPy
+RUN aria2c https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.9-linux_x86_64-portable.tar.bz2 -q -o /opt/pypy-5.9-linux_x86_64-portable.tar.bz2 && \
 	tar xf /opt/pypy-5.9-linux_x86_64-portable.tar.bz2 --use-compress-prog=pbzip2 -C /opt/ && \
 	rm /opt/pypy-5.9-linux_x86_64-portable/README.rst /opt/pypy-5.9-linux_x86_64-portable.tar.bz2 && \
 	ln -s /opt/pypy-5.9-linux_x86_64-portable/bin/pypy /usr/local/bin/
-# Install BEDOPS RUN aria2c https://github.com/bedops/bedops/releases/download/v2.4.29/bedops_linux_x86_64-v2.4.29.tar.bz2 -q -o /opt/bedops_linux_x86_64-v2.4.29.tar.bz2 && \
+# Install BEDOPS
+RUN aria2c https://github.com/bedops/bedops/releases/download/v2.4.29/bedops_linux_x86_64-v2.4.29.tar.bz2 -q -o /opt/bedops_linux_x86_64-v2.4.29.tar.bz2 && \
 	tar xf /opt/bedops_linux_x86_64-v2.4.29.tar.bz2 --use-compress-prog=pbzip2 -C /opt/ && \
 	ln -s /opt/bin/* /usr/local/bin/ && \
 	rm /opt/bedops_linux_x86_64-v2.4.29.tar.bz2
-# Install AfterQC # Use PyPy to run AfterQC as default RUN aria2c https://github.com/OpenGene/AfterQC/archive/v0.9.7.tar.gz -q -o /opt/AfterQC-0.9.7.tar.gz && \
+# Install AfterQC
+# Use PyPy to run AfterQC as default
+RUN aria2c https://github.com/OpenGene/AfterQC/archive/v0.9.7.tar.gz -q -o /opt/AfterQC-0.9.7.tar.gz && \
 	tar xf /opt/AfterQC-0.9.7.tar.gz --use-compress-prog=pigz -C /opt/ && \
 	cd /opt/AfterQC-0.9.7 && \
 	make && \
@@ -117,8 +181,10 @@ FROM ubuntu LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" \
 	rm editdistance/*.cpp editdistance/*.h && \
 	ln -s /opt/AfterQC-0.9.7/*.py /usr/local/bin/ && \
 	rm /opt/AfterQC-0.9.7.tar.gz
-# Install R package LncPipeReporter（via GitHub) RUN Rscript -e "source('http://bioconductor.org/biocLite.R'); install.packages(c('curl', 'httr')); install.packages('devtools'); devtools::install_github('bioinformatist/LncPipeReporter')"
-# Install GffCompare RUN aria2c https://github.com/gpertea/gffcompare/archive/master.zip -q -o /opt/gffcompare-master.zip && \
+# Install R package LncPipeReporter（via GitHub)
+RUN Rscript -e "source('http://bioconductor.org/biocLite.R'); install.packages(c('curl', 'httr')); install.packages('devtools'); devtools::install_github('bioinformatist/LncPipeReporter')"
+# Install GffCompare
+RUN aria2c https://github.com/gpertea/gffcompare/archive/master.zip -q -o /opt/gffcompare-master.zip && \
 	aria2c https://github.com/gpertea/gclib/archive/master.zip -q -o /opt/gclib-master.zip && \
 	unzip -qq /opt/gffcompare-master.zip -d /opt/ && \
 	unzip -qq /opt/gclib-master.zip -d /opt/ && \
@@ -128,7 +194,8 @@ FROM ubuntu LABEL authors="zhaoqi@sysucc.org.cn,sun_yu@mail.nankai.edu.cn" \
 	make release && \
 	rm Makefile README.md gtf_tracking.h *.o *.cpp *.sh && \
 	ln -s /opt/gffcompare-master/gffcompare /usr/local/bin/
-# Install sambamba RUN aria2c https://github.com/biod/sambamba/releases/download/v0.6.7/sambamba_v0.6.7_linux.tar.bz2 -q -o /opt/sambamba_v0.6.7_linux.tar.bz2 && \
+# Install sambamba
+RUN aria2c https://github.com/biod/sambamba/releases/download/v0.6.7/sambamba_v0.6.7_linux.tar.bz2 -q -o /opt/sambamba_v0.6.7_linux.tar.bz2 && \
 	tar xf /opt/sambamba_v0.6.7_linux.tar.bz2 --use-compress-prog=pbzip2 -C /opt/ && \
 	ln -s /opt/sambamba /usr/local/bin/ && \
 	rm /opt/sambamba_v0.6.7_linux.tar.bz2

--- a/LncRNAanalysisPipe.nf
+++ b/LncRNAanalysisPipe.nf
@@ -58,11 +58,11 @@ def print_white = {  str -> ANSI_WHITE + str + ANSI_RESET }
 
 //Help information
 // Nextflow  version
-version="v0.2.4"
+version="v0.2.5"
 //=======================================================================================
 // Nextflow Version check
-if( !nextflow.version.matches('0.26+') ) {
-    println print_yellow("This workflow requires Nextflow version 0.26 or greater -- You are running version ")+ print_red(nextflow.version)
+if( !nextflow.version.matches('0.32+') ) {
+    println print_yellow("This workflow requires Nextflow version 0.32 or greater -- You are running version ")+ print_red(nextflow.version)
     exit 1
 }
 //help information
@@ -217,7 +217,7 @@ if (params.species=="human") {
         touch filenames.txt
         for file in *.gtf
         do
-        perl -lpe 's/ [^"](\\S+) ;/ "$1" ;/g\' $file > ${file}_mod.gtf
+        perl -lpe 's/ ([^"]\\S+) ;/ "$1" ;/g' $file > ${file}_mod.gtf
         echo ${file}_mod.gtf >>filenames.txt
 
         done
@@ -1076,6 +1076,7 @@ process Summary_renaming_and_classification {
     file gencode_protein_coding_gtf from proteinCodingGTF
     file novel_lncRNA_stringent_Gtf from novel_lncRNA_stringent_gtf
     file fasta_ref
+    file mod_file_for_rename
 
     output:
 //    file "lncRNA.final.v2.gtf" into finalLncRNA_gtf
@@ -1087,6 +1088,7 @@ process Summary_renaming_and_classification {
     file "protein_coding.fa" into final_coding_gene_for_CPAT_fa
     file "lncRNA.fa" into final_lncRNA_for_CPAT_fa
     file "lncRNA_classification.txt" into lncRNA_classification
+    file "lncRNA.mapping.file" into rename_mapping_file
     //file "lncRNA.final.CPAT.out" into lncRNA_CPAT_statistic
     //file "protein_coding.final.CPAT.out" into protein_coding_CPAT_statistic
 

--- a/base.config
+++ b/base.config
@@ -1,0 +1,199 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow base config file
+ * -------------------------------------------------
+ * A 'blank slate' config file, appropriate for general
+ * use on most high performace compute environments.
+ * Assumes that all software is installed and available
+ * on the PATH. Runs in `local` mode - all jobs will be
+ * run on the logged in environment.
+ */
+
+process {
+
+  // mimimum allocation
+  cpus = { check_max( 1, 'cpus' ) }
+  memory = { check_max( 2.GB * task.attempt, 'memory' ) }
+  time = { check_max( 1.h * task.attempt, 'time' ) }
+
+  errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : 'terminate' }
+  maxRetries = 3
+  maxErrors = '-1'
+// local, slurm, pbs, lsf, etc etc
+  executor = 'slurm'
+
+  // Process-specific resource requirements
+
+      //  withName: combine_public_annotation {      }
+
+        withName: Make_STARindex {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+          time = { check_max( 5.h * task.attempt, 'time' ) }
+      }
+
+        withName: Make_bowtie2_index {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+          time = { check_max( 5.h * task.attempt, 'time' ) }
+      }
+
+        withName: Make_hisat_index {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 160.GB * task.attempt, 'memory' ) }
+          time = { check_max( 5.h * task.attempt, 'time' ) }
+      }
+
+        //withName: Run_fastQC { }
+
+        withName: Run_afterQC {
+          cpus = { check_max( 6, 'cpus' ) }
+          memory = { check_max( 32.GB * task.attempt, 'memory' ) }
+          time = { check_max( 4.h * task.attempt, 'time' ) }
+      }
+
+        withName: Run_FastP {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 8.GB * task.attempt, 'memory' ) }
+
+      }
+
+        withName: fastq_star_alignment_For_discovery {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+          time = { check_max( 5.h * task.attempt, 'time' ) }
+      }
+
+        withName: fastq_tophat_alignment_For_discovery {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+          time = { check_max( 5.h * task.attempt, 'time' ) }
+      }
+
+        withName: fastq_hisat2_alignment_For_discovery {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 16.GB * task.attempt, 'memory' ) }
+          time = { check_max( 5.h * task.attempt, 'time' ) }
+      }
+
+        withName: StringTie_assembly {
+          cpus = { check_max( 10, 'cpus' ) }
+      }
+
+        withName: StringTie_merge_assembled_gtf {
+          cpus = { check_max( 10, 'cpus' ) }
+      }
+
+        withName: Cufflinks_assembly {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+          time = { check_max( 12.h * task.attempt, 'time' ) }
+      }
+
+        withName: cuffmerge_assembled_gtf {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+          time = { check_max( 12.h * task.attempt, 'time' ) }
+      }
+
+      //  withName: Merge_assembled_gtf_with_GENCODE { }
+
+      //  withName: Identify_novel_lncRNA_with_criterions { }
+
+      //   withName: Predict_coding_abilities_by_PLEK { }
+
+      //  withName: Predict_coding_abilities_by_CPAT { }
+
+      //  withName: Filter_lncRNA_by_coding_potential_result { }
+
+      //  withName: Summary_renaming_and_classification { }
+
+
+      //  withName: Rerun_CPAT_to_evaluate_lncRNA { }
+
+      //  withName: Rerun_CPAT_to_evaluate_coding { }
+
+      //  withName: Secondary_basic_statistic { }
+
+      //  withName: Run_htseq_for_quantification{}
+
+        withName: Run_kallisto_for_quantification {
+          cpus = { check_max( 10, 'cpus' ) }
+          memory = { check_max( 32.GB * task.attempt, 'memory' ) }
+      }
+
+        withName: Build_kallisto_index_of_GTF_for_quantification {
+          cpus = { check_max( 1, 'cpus' ) }
+          memory = { check_max( 64.GB * task.attempt, 'memory' ) }
+          time = { check_max( 2.h * task.attempt, 'time' ) }
+      }
+
+        // withName: Get_HTseq_matrix { }
+
+        // withName: Get_kallisto_matrix { }
+
+        withName: Run_LncPipeReporter {
+        memory = { check_max( 32.GB * task.attempt, 'memory' ) }
+        }
+
+        Run_LncPipeReporter_without_Design {
+        memory = { check_max( 32.GB * task.attempt, 'memory' ) }
+      }
+}
+
+params {
+  // Defaults only, expecting to be overwritten. Set max per cluster node.
+  max_memory = 240.GB
+  max_cpus = 20
+  max_time = 240.h
+}
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+  if(type == 'memory'){
+    try {
+      if(obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+        return params.max_memory as nextflow.util.MemoryUnit
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if(type == 'time'){
+    try {
+      if(obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+        return params.max_time as nextflow.util.Duration
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if(type == 'cpus'){
+    try {
+      return Math.min( obj, params.max_cpus as int )
+    } catch (all) {
+      println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+      return obj
+    }
+  }
+}
+
+timeline {
+  enabled = true
+  file = "${params.out_folder}/pipeline_info/lncPipe_timeline.html"
+}
+report {
+  enabled = true
+  file = "${params.out_folder}/pipeline_info/lncPipe_report.html"
+}
+trace {
+  enabled = true
+  file = "${params.out_folder}/pipeline_info/lncPipe_trace.txt"
+}
+dag {
+  enabled = true
+  file = "${params.out_folder}/pipeline_info/lncPipe_DAG.svg"
+}

--- a/singularity.config
+++ b/singularity.config
@@ -1,43 +1,46 @@
 
-
 params {
 /*
     User setting options (mandatory)
-     */
+*/
+
 // input file and genome reference()
 
-    fastq_ext = '*_{1,2}.fq.gz'
-    fasta_ref = '/data/database/hg38/genome.fa'
-    design = 'design.file' // or null
-    hisat2_index = '/data/database/hg38/hisatIndex/grch38_snp_tran/genome_snp_tran'
-    cpatpath='/opt/CPAT-1.2.3'
+//    fastq_ext = '*_{1,2}.fq.gz'
+
+    fastq_ext = '*_pass_{1,2}.fastq.gz'
+    fasta_ref = '$HOME/kmorris/Group/ref/gencode/GRCh38.p10.genome.fa'
+
+    //
     //human gtf only
-    gencode_annotation_gtf = "/data/database/hg38/Annotation/gencode.v24.annotation.gtf"
-    lncipedia_gtf = "/data/database/hg38/Annotation/lncipedia_4_0_hg38.gtf" // set "null" if you are going to perform analysis on other species
+    gencode_annotation_gtf = "$HOME/kmorris/Group/ref/gencode/gencode.v28.annotation.gtf"
+    lncipedia_gtf = "$HOME/kmorris/Group/ref/lncpedia/lncipedia_5_2_hc_hg38.gtf" // set "null" if you are going to perform analysis on other species
 
 /*
     User setting options (optional)
-     */
-    // tools setting
-    hisat_strand = 'RF'
-    star_index = ''//set if star used
-    bowtie2_index = ''//set if tophat used
-    aligner = "hisat" // or "star","tophat"
+*/
+  // tools setting
+     aligner = "hisat" // or "star","tophat"
+     hisat_strand = 'RF'
+     hisat2_index = '$HOME/kmorris/Group/ref/gencode/HISAT2Index/genome_snp_tran'
+
+     // star_index = '$HOME/kmorris/Group/ref/gencode/STARIndex'
+     // bowtie2_index = ''//set if tophat used
     sam_processor="sambamba"//or "samtools(deprecated)"
     qctools ="fastp"  // or "afterqc","fastp","fastqc","none" to skip qc step
     detools = "edger"//or "deseq2"
     quant = "kallisto"// or 'htseq'
     //other setting
     singleEnd = false
-    unstrand = false
+    unstrand = true
     skip_combine = false
     lncRep_Output = 'reporter.html'
     lncRep_theme = 'npg'
     lncRep_cdf_percent = 10
     lncRep_max_lnc_len = 10000
     lncRep_min_expressed_sample = 50
-    mem=60
-    cpu=30
+    mem = 240
+    cpu = 20
  /*
     for non-human setting
  */
@@ -49,7 +52,7 @@ params {
 /*
 Don't modify
 */
-    cpatpath ='/opt/CPAT-1.2.3'
+cpatpath ='/opt/CPAT-1.2.3'
 
 
 }
@@ -57,24 +60,12 @@ Don't modify
 /*
 Don't modify either
 */
-// Docker options
+// Singularity options
 
 singularity.enabled = true
-process.container = './lncPipe.image'
+process.container = '$HOME/.singularity/lncpipe_rebuild-2018-10-19-ce1bc156744d.simg'
 singularity.autoMounts = true
-// individual process setting
-process.cache = 'deep'
 
-process {
-    withLabel: para {
-        maxForks = 6
-    }
-
-    withLabel: 'qc' {
-        maxForks = 6
-    }
-
-}
 
 manifest {
     homePage = 'https//github.com/likelet/LncPipe'
@@ -82,3 +73,4 @@ manifest {
     mainScript = 'LncRNAanalysisPipe.nf'
 }
 
+includeConfig 'base.config'


### PR DESCRIPTION
Adds config for per-process resource requests, nf-core style (#26); makes slurm the default executor; removes kallisto bootstrapping (not needed without sleuth); default cache; adds pipline_info to results by default; removes para/qc resource allocations; reformatted Dockerfile, but it still fails installing lncPipeReporter. Requires Nextflow 0.32+